### PR TITLE
Wrap the CharacterMap in a Popover

### DIFF
--- a/src/gutenberg-character-map.css
+++ b/src/gutenberg-character-map.css
@@ -45,3 +45,7 @@
 .charMap--categories li a {
 	color: #111;
 }
+
+body:not(.mobile) .character-map-popover .components-popover__content:not(.is-mobile) {
+	min-width: 550px;
+}

--- a/src/gutenberg-character-map.js
+++ b/src/gutenberg-character-map.js
@@ -1,6 +1,8 @@
-const { registerFormatType, toggleFormat } = window.wp.richText;
-const { createElement, Fragment } = window.wp.element;
-const { RichTextToolbarButton, RichTextShortcut } = window.wp.editor;
+const { registerFormatType, toggleFormat } = wp.richText;
+const { createElement, Fragment } = wp.element;
+const { RichTextToolbarButton, RichTextShortcut } = wp.editor;
+const { Popover } = wp.components;
+const { getRectangleFromRange } = wp.dom;
 
 import { CharacterMap } from 'react-character-map';
 import './gutenberg-character-map.css';
@@ -15,6 +17,16 @@ const GutenbergCharacterMap =
 const { name, title, character } = GutenbergCharacterMap;
 const type = `character-map/${ name }`;
 let originalValue;
+
+function getCaretRect() {
+	const range = window.getSelection().getRangeAt( 0 );
+
+	if ( range ) {
+		return getRectangleFromRange( range );
+	}
+}
+
+
 registerFormatType( type, {
 	title,
 	tagName: name,
@@ -29,19 +41,29 @@ registerFormatType( type, {
 
 		if ( isActive ) {
 			return (
-				<CharacterMap
-					onSelect={
-						( char ) => {
-							const slicedNewText = originalValue.text.slice( 0, originalValue.start ) +
-								char.char +
-								originalValue.text.slice( originalValue.end );
-							value.text = slicedNewText;
-							onChange( toggleFormat( value, { type, attributes: { char } } ) );
-							onToggle( false );
-							blur();
+				<Popover
+					className="character-map-popover"
+					position="bottom center"
+					focusOnMount={ false }
+					key="charmap-popover"
+					onClick={ () => {} }
+					getAnchorRect={ getCaretRect }
+				>
+					<CharacterMap
+						onSelect={
+							( char ) => {
+								const slicedNewText = originalValue.text.slice( 0, originalValue.start ) +
+									char.char +
+									originalValue.text.slice( originalValue.end );
+								value.text = slicedNewText;
+								onChange( toggleFormat( value, { type, attributes: { char } } ) );
+								onToggle( false );
+								blur();
+							}
 						}
-					}
-				/>
+						key="charmap"
+					/>
+				</Popover>
 			);
 		}
 


### PR DESCRIPTION
### Description of the Change
Wrap the CharacterMap in a Popover 

### Benefits

Displays the character picker in a  popover. 

### Possible Drawbacks

Neets a little CSS attention, i tried to make the popover wider since we have so much to show, not sure that is the best targeting, mobile looks good already in my testing. Also popover could use a little padding or a border or something?

After CSS change:

![Screencast](https://cl.ly/f9f19943a722/Screen%252520Recording%2525202019-07-09%252520at%25252004.33%252520PM.gif)

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
