### PR TITLE
Release version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [Unreleased] - TBD
 
 ## [1.0.1] - TBD
+### Added
+- Documentation for keyboard shortcut (props @mrwweb, @jeffpaul via #44)
+
 ### Fixed
 - Firefox popover closing immediately after opening the first time (props @adamsilverstein via #41)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+## [1.0.1] - TBD
+### Fixed
+- Firefox popover closing immediately after opening the first time (props @adamsilverstein via #41)
+
 ## [1.0.0] - 2019-08-21
 ### Added
 - Initial plugin release 🎉
 - Wrap [React Character Map](https://github.com/Dayjo/react-character-map) in a Gutenberg Popover (props @adamsilverstein via #1)
 - Plugin header and icon images (props @McCallumDillon via #28)
 
-[Unreleased]: https://github.com/10up/insert-special-characters/compare/1.0.0...master
+[Unreleased]: https://github.com/10up/insert-special-characters/compare/1.0.1...master
+[1.0.1]: https://github.com/10up/insert-special-characters/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/10up/insert-special-characters/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
-## [1.0.1] - TBD
+## [1.0.1] - 2019-09-06
 ### Added
 - Documentation for keyboard shortcut (props @mrwweb, @jeffpaul via #44)
 
 ### Fixed
-- Firefox popover closing immediately after opening the first time (props @adamsilverstein via #41)
+- Ensure character map appears as expected in Firefox (props @adamsilverstein via #41)
 
 ## [1.0.0] - 2019-08-21
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,11 @@ The `develop` branch is the development branch which means it contains the next 
 
 1. Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
 2. Version bump: Bump the version number in `insert-special-characters.php` and `package.json` if it does not already reflect the version being released.
-3. Changelog: Add/update the changelog in `CHANGELOG.md`
+3. Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`
 4. Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
 5. Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `master`. `master` contains the stable development version.
 6. Push: Push your master branch to GitHub, e.g. `git push origin master`.
 7. Git tag: Create a [new release](https://github.com/10up/insert-special-characters/releases/new) as `X.Y.Z` on the `master` branch in GitHub.
 8. Deploy to WordPress.org: Head to the [Actions](https://github.com/10up/insert-special-characters/actions) tab in the repo and wait for the Deploy to WordPress.org workflow to finish if it hasn't already. If it doesn't succeed, figure out why and head back to delete the tag and try again.
+9. Edit the [X.Y.Y milestone](https://github.com/10up/insert-special-characters/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the `X.Y.Z` milestone.
+10. If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1` or `Future Release`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,5 +36,5 @@ The `develop` branch is the development branch which means it contains the next 
 6. Push: Push your master branch to GitHub, e.g. `git push origin master`.
 7. Git tag: Create a [new release](https://github.com/10up/insert-special-characters/releases/new) as `X.Y.Z` on the `master` branch in GitHub.
 8. Deploy to WordPress.org: Head to the [Actions](https://github.com/10up/insert-special-characters/actions) tab in the repo and wait for the Deploy to WordPress.org workflow to finish if it hasn't already. If it doesn't succeed, figure out why and head back to delete the tag and try again.
-9. Edit the [X.Y.Y milestone](https://github.com/10up/insert-special-characters/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the `X.Y.Z` milestone.
+9. Edit the [X.Y.Z milestone](https://github.com/10up/insert-special-characters/milestone/#) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close the `X.Y.Z` milestone.
 10. If any open issues or PRs which were milestoned for `X.Y.Z` do not make it into the release, update their milestone to `X.Y.Z+1` or `Future Release`.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -10,7 +10,7 @@ The following individuals are responsible for curating the list of issues, respo
 
 Thank you to all the people who have already contributed to this repository via bug reports, code, design, ideas, project management, translation, testing, etc.
 
-[Adam Silverstein (@adamsilverstein)](https://github.com/adamsilverstein), [Helen Hou-Sandi (@helen)](https://github.com/helen), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul)
+[Adam Silverstein (@adamsilverstein)](https://github.com/adamsilverstein), [Helen Hou-Sandi (@helen)](https://github.com/helen), [Jeffrey Paul (@jeffpaul)](https://github.com/jeffpaul), [Mark Root-Wiley (@mrwweb)](https://github.com/mrwweb)
 
 ## Libraries
 

--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Insert Special Characters
  * Plugin URI:        https://github.com/10up/insert-special-characters
  * Description:       A Special Character inserter for the WordPress block editor (Gutenberg).
- * Version:           1.0.0
+ * Version:           1.0.1
  * Requires at least: 5.2
  * Requires PHP:      5.6
  * Author:            10up

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insert-special-characters",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "insert-special-characters.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -41,7 +41,7 @@ Added
 * Documentation for keyboard shortcut (props [@mrwweb](https://profiles.wordpress.org/mrwweb/), [@jeffpaul](https://profiles.wordpress.org/jeffpaul/))
 
 Fixed
-* Firefox popover closing immediately after opening the first time (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* Ensure character map appears as expected in Firefox (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
 
 = 1.0.0 =
 Added

--- a/readme.txt
+++ b/readme.txt
@@ -35,8 +35,12 @@ Development takes place in the GitHub repository: https://github.com/10up/insert
 
 == Changelog ==
 
+= 1.0.1 =
+Fixed
+* Firefox popover closing immediately after opening the first time (props @adamsilverstein)
+
 = 1.0.0 =
-== Added ==
+Added
 * Initial plugin release 🎉
 * Wrap [React Character Map](https://github.com/Dayjo/react-character-map) in a Gutenberg Popover (props @adamsilverstein)
 * Plugin header and icon images (props @dillonmccallum)

--- a/readme.txt
+++ b/readme.txt
@@ -12,8 +12,7 @@ A Special Character inserter for the WordPress block editor (Gutenberg).
 
 == Description ==
 
-A Special Character inserter for the WordPress block editor (Gutenberg).
-Requires PHP 5.6+ and WordPress 5.2+.
+Ever wanted to add a special character while working within the WordPress block editor (Gutenberg) and suddenly find yourself longing for the days of the Classic Editor and the Special Character inserter? Well long no more, the Insert Special Characters plugin is here to ease your publishing woes!
 
 Development takes place in the [GitHub repository](https://github.com/10up/insert-special-characters).
 

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,9 @@ Development takes place in the [GitHub repository](https://github.com/10up/inser
 == Changelog ==
 
 = 1.0.1 =
+Added
+* Documentation for keyboard shortcut (props [@mrwweb](https://profiles.wordpress.org/mrwweb/), [@jeffpaul](https://profiles.wordpress.org/jeffpaul/))
+
 Fixed
 * Firefox popover closing immediately after opening the first time (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
 

--- a/readme.txt
+++ b/readme.txt
@@ -15,13 +15,13 @@ A Special Character inserter for the WordPress block editor (Gutenberg).
 A Special Character inserter for the WordPress block editor (Gutenberg).
 Requires PHP 5.6+ and WordPress 5.2+.
 
-Development takes place in the GitHub repository: https://github.com/10up/insert-special-characters.
+Development takes place in the [GitHub repository](https://github.com/10up/insert-special-characters).
 
 === Technical Notes ===
 
 * Requires PHP 5.6+.
 * Requires [WordPress](http://wordpress.org/) 5.2+
-* Issues and Pull requests welcome in the GitHub repository: https://github.com/10up/insert-special-characters.
+* Issues and Pull requests welcome in the [GitHub repository](https://github.com/10up/insert-special-characters).
 
 == Screenshots ==
 
@@ -37,10 +37,10 @@ Development takes place in the GitHub repository: https://github.com/10up/insert
 
 = 1.0.1 =
 Fixed
-* Firefox popover closing immediately after opening the first time (props @adamsilverstein)
+* Firefox popover closing immediately after opening the first time (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
 
 = 1.0.0 =
 Added
 * Initial plugin release 🎉
-* Wrap [React Character Map](https://github.com/Dayjo/react-character-map) in a Gutenberg Popover (props @adamsilverstein)
-* Plugin header and icon images (props @dillonmccallum)
+* Wrap [React Character Map](https://github.com/Dayjo/react-character-map) in a Gutenberg Popover (props [@adamsilverstein](https://profiles.wordpress.org/adamsilverstein/))
+* Plugin header and icon images (props [@dillonmccallum](https://profiles.wordpress.org/dillonmccallum/))

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Special Characters, Character Map, Omega, Gutenberg, Block, block editor
 Requires at least: 5.2
 Tested up to: 5.2
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: MIT
 License URI: http://www.gnu.org/licenses/mit.html
 


### PR DESCRIPTION
PR for tracking changes for the 1.0.1 release. Target release date: **Monday, August 9th.**

### [Release steps](https://github.com/10up/insert-special-characters/blob/develop/CONTRIBUTING.md#release-instructions)

- [x] Starting from `develop`, cut a release branch named `release/1.0.1` for your changes.
- [x] Version bump: Bump the version number in `insert-special-characters.php` and `package.json` if it does not already reflect the version being released.
- [x] Changelog: Add/update the changelog in `CHANGELOG.md` and `readme.txt`
- [x] Check to be sure any new files/paths that are unnecessary in the production version are included in `.distignore`.
- [ ] Merge: Make a non-fast-forward merge from your release branch to `develop` (or merge the pull request), then do the same for `develop` into `master`. `master` contains the stable development version.
- [ ] Push: Push your master branch to GitHub, e.g. `git push origin master`.
- [ ] Git tag: Create a [new release](https://github.com/10up/insert-special-characters/releases/new) as `1.0.1` on the `master` branch in GitHub.
- [ ] Deploy to WordPress.org: Head to the [Actions](https://github.com/10up/insert-special-characters/actions) tab in the repo and wait for the Deploy to WordPress.org workflow to finish if it hasn't already. If it doesn't succeed, figure out why and head back to delete the tag and try again.
- [ ] Edit the [1.0.1 milestone](https://github.com/10up/insert-special-characters/milestone/4) with release date (in the `Due date (optional)` field) and link to GitHub release (in the `Description` field), then close `1.0.1` milestone
- [ ] If any open issues or PRs which were milestoned for `1.0.1` do not make it into the release, update their milestone to `1.1.0` or `Future Release`