### PR TITLE
Attach text domain to script for translations

### DIFF
--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -28,5 +28,7 @@ function gcm_block_enqueue_scripts() {
 		'',
 		true
 	);
+	
+	wp_set_script_translations( 'insert-special-characters', 'insert-special-characters' );
 }
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\gcm_block_enqueue_scripts' );


### PR DESCRIPTION
### Description of the Change

Adds the missing `wp_set_script_translations()` call, see #51.

### Checklist:


- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

Register text domain to ensure translations can be loaded.