### PR TITLE
Focus search input on mount

### DIFF
--- a/src/insert-special-characters.js
+++ b/src/insert-special-characters.js
@@ -1,5 +1,5 @@
 const { registerFormatType, toggleFormat, insert } = wp.richText;
-const { createElement, Fragment } = wp.element;
+const { createElement, Fragment, Component } = wp.element;
 const { RichTextToolbarButton, RichTextShortcut } = wp.editor;
 const { Popover } = wp.components;
 const { getRectangleFromRange } = wp.dom;
@@ -22,6 +22,27 @@ const InsertSpecialCharactersOptions = {
 const { name, title, character } = InsertSpecialCharactersOptions;
 const type = `special-characters/${ name }`;
 let anchorRange;
+
+class WithInputFocus extends Component {
+	/**
+	 * Scroll to the top of the inner container and focus the search input on mount.
+	 */
+	componentDidMount() {
+		const filterInput = document.querySelector( '.charMap--filter input[name="filter"]' )
+
+		// This works best with a slight delay.
+		setTimeout( () => {
+			if ( filterInput && 'focus' in filterInput ) {
+				filterInput.focus();
+			}
+		}, 25 );
+	}
+
+
+	render() {
+		return this.props.children;
+	}
+}
 
 /**
  * Register the "Format Type" to create the character inserter.
@@ -51,33 +72,36 @@ registerFormatType( type, {
 
 		// Display the character map when it is active.
 		if ( isActive ) {
-			const characters = applyFilters(  `${name}-characters`, Chars );
+			const characters = applyFilters( `${name}-characters`, Chars );
 			return (
-				<Popover
-					className="character-map-popover"
-					position="bottom center"
-					focusOnMount="container"
-					key="charmap-popover"
-					onClick={ () => {} }
-					getAnchorRect={ anchorRect }
-					expandOnMobile={ true }
-					headerTitle={ __( 'Insert Special Character', 'insert-special-characters' ) }
-					onClose={ () => {
-						onChange( toggleFormat( value, { type } ) );
-					} }
-				>
-					<CharacterMap
-						characterData={ characters }
-						onSelect={
+				<WithInputFocus>
+					<Popover
+						animate={ false }
+						className="character-map-popover"
+						position="bottom center"
+						focusOnMount={ false }
+						key="charmap-popover"
+						onClick={ () => {} }
+						getAnchorRect={ anchorRect }
+						expandOnMobile={ true }
+						headerTitle={ __( 'Insert Special Character', 'insert-special-characters' ) }
+						onClose={ () => {
+							onChange( toggleFormat( value, { type } ) );
+						} }
+					>
+						<CharacterMap
+							characterData={ characters }
+							onSelect={
 
-							// Insert the selected character and close the popover.
-							( char ) => {
-								onChange( insert( value, char.char ) );
+								// Insert the selected character and close the popover.
+								( char ) => {
+									onChange( insert( value, char.char ) );
+								}
 							}
-						}
-						key="charmap"
-					/>
-				</Popover>
+							key="charmap"
+						/>
+					</Popover>
+				</WithInputFocus>
 			);
 		}
 


### PR DESCRIPTION
Note: Submitting this in WIP status because it may not be needed. I also submitted this PR to the upstream repo: https://github.com/Dayjo/react-character-map/pull/17/files That would make this mostly obsolete.

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This would resolve #49 by focusing the search input when the component mounts. 

It also takes care of this issue: 

![ezgif com-resize](https://user-images.githubusercontent.com/9020968/74304407-87281800-4d22-11ea-96f6-517cce86557f.gif)

(In certain positions the popover opens with the scrollbar at the bottom. This seems related to the optional animation that runs when the popover mounts; I turned animation off.)

<!--
We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.  Please include screenshots (if appropriate).
-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., commands you ran, text you typed, buttons you clicked) and describe the results you observed.
-->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
