### PR TITLE
bump wp tested-up-to 5.7 in readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A Special Character inserter for the WordPress block editor (Gutenberg).
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/insert-special-characters.svg)](https://github.com/10up/insert-special-characters/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.6%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/insert-special-characters.svg)](https://github.com/10up/insert-special-characters/blob/develop/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/insert-special-characters.svg)](https://github.com/10up/insert-special-characters/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v5.7%20tested-success.svg) [![GPLv2 License](https://img.shields.io/github/license/10up/insert-special-characters.svg)](https://github.com/10up/insert-special-characters/blob/develop/LICENSE.md)
 
 ## Overview
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === Insert Special Characters ===
-Contributors:  10up, adamsilverstein
-Tags: Special Characters, Character Map, Omega, Gutenberg, Block, block editor
+Contributors:      10up, adamsilverstein
+Tags:              Special Characters, Character Map, Omega, Gutenberg, Block, block editor
 Requires at least: 5.2
-Tested up to: 5.6
-Requires PHP: 5.6
-Stable tag: 1.0.2
-License: GPLv2
-License URI: insert-special-characters.php
+Tested up to:      5.7
+Requires PHP:      5.6
+Stable tag:        1.0.2
+License:           GPLv2
+License URI:       insert-special-characters.php
 
 A Special Character inserter for the WordPress block editor (Gutenberg).
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This PR bumps the WordPress "tested up to" value to 5.7

### Alternate Designs

n/a

### Benefits

Ensures we're testing and noting what latest version Insert Special Characters is validated to work with.

### Possible Drawbacks

none identified

### Verification Process

Ran local WP 5.7 instance, installed ISC 1.0.2, added Post and Page with Special Characters and items displayed in the block editor and on published Post and Page as expected.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #83.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
