### PR TITLE
Fix Popover initial focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ registerFormatType( type, {
 				<Popover
 					className="character-map-popover"
 					position="bottom center"
-					focusOnMount="container"
+					focusOnMount="firstElement"
 					key="charmap-popover"
 					onClick={ () => {} }
 					getAnchorRect={ anchorRect }


### PR DESCRIPTION
### Description of the Change

This PR fixes the popover initial focus when it is opened. See image below of the issue. 

![40b9a53bf9b0c8ca220f9958525fdfa6](https://user-images.githubusercontent.com/3365507/125841439-5649adb0-0c22-42b7-bac0-ece3eac7a829.gif)


### Verification Process

Activate Twenty Twenty One theme. Make sure that the popover is displaying from the top instead of bottom or center of the contents. 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
