### PR TITLE
Compatibility fixes with the new WP 5.8 widget screen

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const { registerFormatType, toggleFormat, insert } = wp.richText;
-const { createElement, Fragment } = wp.element;
-const { RichTextToolbarButton, RichTextShortcut } = wp.editor;
+const { Fragment } = wp.element;
+const { RichTextToolbarButton, RichTextShortcut } = wp.blockEditor;
 const { Popover } = wp.components;
 const { getRectangleFromRange } = wp.dom;
 const { applyFilters } = wp.hooks;
@@ -110,23 +110,23 @@ registerFormatType( type, {
 			);
 		}
 
-		return createElement(
-			Fragment,
-			null,
-			createElement( RichTextShortcut, {
-				type: 'primary',
-				character,
-				onUse: onToggle,
-			} ),
-			createElement( RichTextToolbarButton, {
-				title,
-				onClick: onToggle,
-				isActive,
-				shortcutType: 'primary',
-				shortcutCharacter: character,
-				className: `toolbar-button-with-text toolbar-button__advanced-${ name }`,
-				icon: 'editor-customchar',
-			} )
+		return (
+			<Fragment>
+				<RichTextShortcut
+					type="primary"
+					character={ character }
+					onUse={ onToggle }
+				/>
+				<RichTextToolbarButton
+					className={ `toolbar-button-with-text toolbar-button__advanced-${ name }` }
+					icon="editor-customchar"
+					title={ title }
+					onClick={ onToggle }
+					isActive={ isActive }
+					shortcutType="primary"
+					shortcutCharacter={ character }
+				/>
+			</Fragment>
 		);
 	},
 } );


### PR DESCRIPTION
### Description of the Change

This PR fixes the error on the new WordPress 5.8 widget screen when the plugin is activated. Additionally, I changed the formatting of the returned elements.


### Verification Process
Add paragraph block in any of the widgets in the new Gutenberg widget screen and make sure that the block is working as expected and the Insert Character format is working. Thanks!

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Relates to #95.

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
