### PR TITLE
Fix/30: Overflow added to content popover in mobile screens.

### DIFF
--- a/src/insert-special-characters.css
+++ b/src/insert-special-characters.css
@@ -73,3 +73,7 @@ ul.charMap--category {
 body:not(.mobile) .character-map-popover .components-popover__content:not(.is-mobile) {
 	min-width: 550px;
 }
+
+body.mobile .components-popover.is-expanded {
+	overflow: scroll;
+}


### PR DESCRIPTION
### Description of the Change
On Mobile devices, the scroll bar in the popover wasn't able to reach all the characters.  I have added an overflow CSS to allow the popover to add scrolling behaviour.

### Designs

Desktop Behaviour - https://share.getcloudapp.com/6quv0BdP
Mobile Behaviour - https://share.getcloudapp.com/NQu7dDR9

### Benefits
Now the whole list of the characters is accessible on the mobile devices.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Please try to add open the special characters popup on desktop as well as mobile devices and you should be able to access all the icons.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
https://github.com/10up/insert-special-characters/issues/30

### Changelog Entry
Fix: Character map popover scrolling issue on mobile viewport
