### PR TITLE
Bump our minimum supported version of WordPress to 5.5

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.4'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.5'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -4,7 +4,7 @@
  * Plugin URI:        https://github.com/10up/insert-special-characters
  * Description:       A Special Character inserter for the WordPress block editor (Gutenberg).
  * Version:           1.0.4
- * Requires at least: 5.4
+ * Requires at least: 5.5
  * Requires PHP:      5.6
  * Author:            10up
  * Author URI:        https://10up.com

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Insert Special Characters ===
 Contributors:      10up, adamsilverstein
 Tags:              Special Characters, Character Map, Omega, Gutenberg, Block, block editor
-Requires at least: 5.4
+Requires at least: 5.5
 Tested up to:      6.0
 Stable tag:        1.0.4
 Requires PHP:      5.6

--- a/tests/cypress/integration/insert-character-in-post.test.js
+++ b/tests/cypress/integration/insert-character-in-post.test.js
@@ -16,40 +16,20 @@ describe( 'Insert character in post', () => {
 			.contains( 'Page with special characters' )
 			.click();
 
-		cy.get( 'body' ).then( ( $body ) => {
-			// WP 5.4
-			if ( $body.find( '.nux-dot-tip__disable' ).length > 0 ) {
-				cy.get( '.nux-dot-tip__disable' ).click();
-			} else {
-				cy.get( 'button[aria-label="Close dialog"]' ).click();
-			}
-		} );
+		cy.get( 'button[aria-label="Close dialog"]' ).click();
 
 		/**
 		 * Click block inserter.
 		 */
-		cy.get( 'body' ).then( ( $body ) => {
-			// WP 5.4
-			if (
-				$body.find(
-					'.edit-post-header-toolbar .block-editor-inserter__toggle'
-				).length > 0
-			) {
-				cy.get(
-					'.edit-post-header-toolbar .block-editor-inserter__toggle'
-				).click();
-			} else {
-				cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
-			}
-		} );
+		cy.get( '.edit-post-header-toolbar__inserter-toggle' ).click();
 
 		/**
 		 * Search for paragraph block in inserter.
 		 */
 		cy.get( 'body' ).then( ( $body ) => {
-			// WP 5.4
-			if ( $body.find( '.block-editor-inserter__search' ).length > 0 ) {
-				cy.get( '.block-editor-inserter__search' ).type( 'Paragraph' );
+			// WP 5.5
+			if ( $body.find( '.block-editor-inserter__search-input' ).length > 0 ) {
+				cy.get( '.block-editor-inserter__search-input' ).type( 'Paragraph' );
 			} else {
 				cy.get( '.components-search-control__input' ).type(
 					'Paragraph'
@@ -62,9 +42,18 @@ describe( 'Insert character in post', () => {
 		/**
 		 * Add content to paragraph.
 		 */
-		cy.get( '.wp-block-paragraph' )
-			.click()
-			.type( 'Hello world' );
+		cy.get( 'body' ).then( ( $body ) => {
+			// WP 5.5
+			if ( $body.find( 'p[data-type="core/paragraph"]' ).length > 0 ) {
+				cy.get( 'p[data-type="core/paragraph"]' )
+					.click()
+					.type( 'Hello world' );
+			} else {
+				cy.get( '.wp-block-paragraph' )
+					.click()
+					.type( 'Hello world' );
+			}
+		} );
 
 		/**
 		 * Open block list view.

--- a/tests/cypress/integration/insert-character-in-post.test.js
+++ b/tests/cypress/integration/insert-character-in-post.test.js
@@ -28,8 +28,12 @@ describe( 'Insert character in post', () => {
 		 */
 		cy.get( 'body' ).then( ( $body ) => {
 			// WP 5.5
-			if ( $body.find( '.block-editor-inserter__search-input' ).length > 0 ) {
-				cy.get( '.block-editor-inserter__search-input' ).type( 'Paragraph' );
+			if (
+				$body.find( '.block-editor-inserter__search-input' ).length > 0
+			) {
+				cy.get( '.block-editor-inserter__search-input' ).type(
+					'Paragraph'
+				);
 			} else {
 				cy.get( '.components-search-control__input' ).type(
 					'Paragraph'


### PR DESCRIPTION
### Description of the Change

While prepping for the 1.0.5 release I realized our E2E tests were failing on WP 5.4, which was our minimum supported version. This was due to changes introduced in #130 that rely on a certain HTML structure. In discussion there, it was determined to bump our minimum version up to where those changes were introduced in WP, which is 5.5.

### Alternate Designs

Could fix the JS introduced in #130 to work on 5.4

### Possible Drawbacks

Any user's running on WP 5.4 won't be able to update

### Verification Process

Verify the WP Minimum E2E test passes (the other two are failing due to timeouts, which seems to have been the case for a bit)

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/.github/blob/trunk/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Changed - Bump our minimum supported WordPress version to 5.5

### Credits

Props @dkotter, @jeffpaul, @peterwilsoncc 
