### PR TITLE
Update WordPress version in readme to match plugin file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ wp.hooks.addFilter(
 ## Requirements
 
 * PHP 5.6+
-* [WordPress](http://wordpress.org/) 5.2+
+* [WordPress](http://wordpress.org/) 5.5+
 
 ## Installation
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Development takes place in the [GitHub repository](https://github.com/10up/inser
 == Technical Notes ==
 
 * Requires PHP 5.6+.
-* Requires [WordPress](http://wordpress.org/) 5.2+
+* Requires [WordPress](http://wordpress.org/) 5.5+
 * Issues and Pull requests welcome in the [GitHub repository](https://github.com/10up/insert-special-characters).
 
 == Installation ==


### PR DESCRIPTION
### Description of the Change

The WordPress version was bumped here: https://github.com/10up/insert-special-characters/commit/6ebd47146d9bc4184bfff7cd305ef27ac0e5e858 but was missed in a few places. This PR fixes those.

### Changelog Entry
> Changed - Updated minimum WordPress version in a few more places

### Credits
Props @grappler