### PR TITLE
Fix for Popover grid positioning in the FSE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,10 +36,11 @@ registerFormatType( type, {
 	/**
 	 * The `edit` function is called when the Character Map is selected.
 	 *
-	 * @param {Object}   props          Props object.
-	 * @param {boolean}  props.isActive State of popover.
-	 * @param {boolean}  props.value    State of popover.
-	 * @param {Function} props.onChange Event handler to detect range selection.
+	 * @param {Object}      props            Props object.
+	 * @param {boolean}     props.isActive   State of popover.
+	 * @param {boolean}     props.value      State of popover.
+	 * @param {Function}    props.onChange   Event handler to detect range selection.
+	 * @param {HTMLElement} props.contentRef The editable element.
 	 */
 	edit( { isActive, value, onChange, contentRef } ) {
 		const onToggle = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -41,20 +41,9 @@ registerFormatType( type, {
 	 * @param {boolean}  props.value    State of popover.
 	 * @param {Function} props.onChange Event handler to detect range selection.
 	 */
-	edit( { isActive, value, onChange } ) {
+	edit( { isActive, value, onChange, contentRef } ) {
 		const onToggle = () => {
-			let theDocument;
-
-			// Needs review, this feels 'dirty', gotta be a better way to check for & select the FSE iframe.
-			const fseIframe = document.getElementsByName('editor-canvas')[0];
-			if ( fseIframe ) {
-				theDocument = fseIframe.contentDocument ||  fseIframe.contentWindow.document;
-			} else {
-				// FSE not avaiable, use the current document.
-				theDocument = document.defaultView;
-			}
-
-			const selection = theDocument.getSelection();
+			const selection = contentRef.current.ownerDocument.getSelection();
 
 			anchorRange =
 				selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,18 @@ registerFormatType( type, {
 	 */
 	edit( { isActive, value, onChange } ) {
 		const onToggle = () => {
-			// Set up the anchorRange when the Popover is opened.
-			const selection = document.defaultView.getSelection();
+			let theDocument;
+
+			// Needs review, this feels 'dirty', gotta be a better way to check for & select the FSE iframe.
+			const fseIframe = document.getElementsByName('editor-canvas')[0];
+			if ( fseIframe ) {
+				theDocument = fseIframe.contentDocument ||  fseIframe.contentWindow.document;
+			} else {
+				// FSE not avaiable, use the current document.
+				theDocument = document.defaultView;
+			}
+
+			const selection = theDocument.getSelection();
 
 			anchorRange =
 				selection.rangeCount > 0 ? selection.getRangeAt( 0 ) : null;


### PR DESCRIPTION
### Description of the Change

Fixes the Popover grid positioning in the FSE.

Closes #198

### How to test the Change

1. Go to the FSE & edit a template or page
2. Add/edit a text component, then click on the insert character button in the toolbar
3. Popover should appear close to the caret

### Changelog Entry

> Fixed - Fix for the Popover grid positioning in the FSE


### Credits

Props @bmarshall511 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
