### PR TITLE
Fix an issue where highlighting a format would error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,17 +82,22 @@ registerFormatType( type, {
 						( char ) => {
 							const newValue = {
 								...value,
-								// duplicate the format at the value start to ensure the
-								// formats array is the correct size and formatted correctly.
-								formats: value.formats.splice(
-									value.start,
-									0,
-									value.formats.at( value.start )
-								),
+								// grab the format at the start position,
+								// if it is undefined then use an empty array.
+								formats: value.formats.at( value.start )
+									? [ value.formats.at( value.start ) ]
+									: [],
 								text: char.char,
 							};
 
-							onChange( insert( value, newValue ) );
+							onChange(
+								insert(
+									value,
+									newValue,
+									newValue.start,
+									newValue.end
+								)
+							);
 						}
 					}
 					categoryNames={ {


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This PR fixes an issue where highlighting a newly inserted special character that has no formatting will cause the block to error. The change alters how the character is inserted by specifically targeting the correct start/end and setting the formats array to an empty array instead of `[ undefined ]` (the source of the error).

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #203 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Add some text to a paragraph
2. Insert a special character
3. Highlight the text using a mouse 
4. ensure it doesn't error

### Video of the change in action

https://github.com/10up/insert-special-characters/assets/7556775/e8bbcd98-dd31-4688-8686-37fb428813d9


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Highlighting a special character that has no formats crashes the block

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] All new and existing tests pass.
