### PR TITLE
Add a check to ensure we have a valid PHP version before loading plugin functionality and output an admin notice if needed

### DIFF
--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Install dependencies
         run: composer install
 
-      - name: Run PHP Compatibility
-        run: vendor/bin/phpcs insert-special-characters.php --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-
+      - name: Run PHP Compatibility on all files.
+        run: vendor/bin/phpcs inc --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 7.4-
+
+      - name: Run PHP Compatibility on main file.
+        run: vendor/bin/phpcs insert-special-characters.php --standard=PHPCompatibilityWP --extensions=php --runtime-set testVersion 5.6-

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -106,9 +106,9 @@ function render_isc_writing_setting() {
 	<p>
 		<label for="tenup_isc_most_read_palette">
 			<input
-					type="checkbox"
-					name="tenup_isc_most_read_palette"
-					id="tenup_isc_most_read_palette"
+				type="checkbox"
+				name="tenup_isc_most_read_palette"
+				id="tenup_isc_most_read_palette"
 				<?php checked( $option, true, true ); ?>
 			>
 			<?php esc_html_e( 'Check this to enable the most used character palette.', 'insert-special-characters' ); ?>

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Registers JS and CSS assets.
+ */
+namespace InsertSpecialCharacters;
+
+/**
+ * Registers JS and CSS assets.
+ */
+function register_assets() {
+	$asset_data_file = trailingslashit( ISC_PLUGIN_PATH ) . 'build/index.asset.php';
+
+	if ( ! file_exists( $asset_data_file ) ) {
+		return;
+	}
+
+	$script_data = include $asset_data_file;
+
+	wp_register_script(
+		'insert-special-characters',
+		ISC_PLUGIN_URL . 'build/index.js',
+		$script_data['dependencies'],
+		$script_data['version'],
+		true
+	);
+
+	wp_register_style(
+		'insert-special-characters-css',
+		ISC_PLUGIN_URL . 'build/index.css',
+		array(),
+		$script_data['version']
+	);
+
+	wp_set_script_translations( 'insert-special-characters', 'insert-special-characters', ISC_PLUGIN_PATH . 'languages' );
+}
+
+add_action( 'init', __NAMESPACE__ . '\register_assets' );
+
+
+/**
+ * Enqueue the admin JavaScript assets.
+ */
+function gcm_block_enqueue_scripts() {
+
+	wp_enqueue_script( 'insert-special-characters' );
+
+	wp_enqueue_style( 'insert-special-characters-css' );
+
+	wp_add_inline_script(
+		'insert-special-characters',
+		sprintf(
+			'var tenupIscVars = window.tenupIscVars || {}; tenupIscVars = %1$s',
+			wp_json_encode(
+				array(
+					'most_read_palette' => get_most_used_palette_setting(),
+				)
+			)
+		)
+	);
+}
+add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\gcm_block_enqueue_scripts' );
+
+/**
+ * Registers settings fields.
+ */
+function register_settings_fields() {
+	register_setting(
+		'writing',
+		'tenup_isc_most_read_palette',
+		array(
+			'type'         => 'boolean',
+			'show_in_rest' => true,
+			'default'      => false,
+		)
+	);
+
+	add_settings_section(
+		'tenup_isc_writing_section',
+		esc_html__( 'Insert Special Characters', 'insert-special-characters' ),
+		null,
+		'writing'
+	);
+
+	add_settings_field(
+		'tenup_isc_most_read_palette',
+		esc_html__( 'Most used characters palette', 'insert-special-characters' ),
+		__NAMESPACE__ . '\render_isc_writing_setting',
+		'writing',
+		'tenup_isc_writing_section',
+		array(
+			'label_for' => 'tenup_isc_most_read_palette',
+		)
+	);
+}
+add_action( 'admin_init', __NAMESPACE__ . '\register_settings_fields' );
+
+/**
+ * Renders settings fields.
+ */
+function render_isc_writing_setting() {
+	$option = get_most_used_palette_setting();
+	?>
+    <p>
+        <label for="tenup_isc_most_read_palette">
+            <input
+                    type="checkbox"
+                    name="tenup_isc_most_read_palette"
+                    id="tenup_isc_most_read_palette"
+				<?php checked( $option, true, true ); ?>
+            >
+			<?php esc_html_e( 'Check this to enable the most used character palette.', 'insert-special-characters' ); ?>
+        </label>
+    </p>
+
+	<?php if ( $option ) : ?>
+        <p>
+            <button class="button secondary" id="isc_reset_palette" type="button" style="margin-top: 16px;">
+				<?php esc_html_e( 'Clear palette', 'insert-special-characters' ); ?>
+            </button>
+            &nbsp;
+			<?php esc_html_e( 'Press this to clear palette data.', 'insert-special-characters' ); ?>
+        </p>
+	<?php
+	endif;
+}
+
+/**
+ * Helper function to get most used character palette setting.
+ *
+ * @return boolean
+ */
+function get_most_used_palette_setting() {
+	return 'on' === get_option( 'tenup_isc_most_read_palette' );
+}
+
+/**
+ * Loads admin scripts.
+ *
+ * @param string $hook The current admin page.
+ */
+function load_admin_scripts( $hook ) {
+	if ( 'options-writing.php' !== $hook ) {
+		return;
+	}
+
+	$asset_data_file = trailingslashit( ISC_PLUGIN_PATH ) . 'build/admin.asset.php';
+
+	if ( ! file_exists( $asset_data_file ) ) {
+		return;
+	}
+
+	$script_data = include $asset_data_file;
+
+	wp_enqueue_script(
+		'insert-special-characters-admin-js',
+		ISC_PLUGIN_URL . 'build/admin.js',
+		$script_data['dependencies'],
+		$script_data['version'],
+		true
+	);
+
+	wp_localize_script(
+		'insert-special-characters-admin-js',
+		'tenupIscAdminVars',
+		array(
+			'palette_deleted_message' => __( 'Palette cleared', 'insert-special-characters' ),
+		)
+	);
+}
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\load_admin_scripts' );

--- a/inc/plugin.php
+++ b/inc/plugin.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Registers JS and CSS assets.
+ *
+ * @package insert-special-characters
  */
+
 namespace InsertSpecialCharacters;
 
 /**
@@ -100,27 +103,27 @@ add_action( 'admin_init', __NAMESPACE__ . '\register_settings_fields' );
 function render_isc_writing_setting() {
 	$option = get_most_used_palette_setting();
 	?>
-    <p>
-        <label for="tenup_isc_most_read_palette">
-            <input
-                    type="checkbox"
-                    name="tenup_isc_most_read_palette"
-                    id="tenup_isc_most_read_palette"
+	<p>
+		<label for="tenup_isc_most_read_palette">
+			<input
+					type="checkbox"
+					name="tenup_isc_most_read_palette"
+					id="tenup_isc_most_read_palette"
 				<?php checked( $option, true, true ); ?>
-            >
+			>
 			<?php esc_html_e( 'Check this to enable the most used character palette.', 'insert-special-characters' ); ?>
-        </label>
-    </p>
+		</label>
+	</p>
 
 	<?php if ( $option ) : ?>
-        <p>
-            <button class="button secondary" id="isc_reset_palette" type="button" style="margin-top: 16px;">
+		<p>
+			<button class="button secondary" id="isc_reset_palette" type="button" style="margin-top: 16px;">
 				<?php esc_html_e( 'Clear palette', 'insert-special-characters' ); ?>
-            </button>
-            &nbsp;
+			</button>
+			&nbsp;
 			<?php esc_html_e( 'Press this to clear palette data.', 'insert-special-characters' ); ?>
-        </p>
-	<?php
+		</p>
+		<?php
 	endif;
 }
 

--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -17,6 +17,9 @@
 
 namespace InsertSpecialCharacters;
 
+define( 'ISC_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'ISC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
 /**
  * Get the minimum version of PHP required by this plugin.
  *
@@ -24,7 +27,7 @@ namespace InsertSpecialCharacters;
  *
  * @return string Minimum version required.
  */
-function minimum_php_requirement(): string {
+function minimum_php_requirement() {
 	return '7.4';
 }
 
@@ -35,7 +38,7 @@ function minimum_php_requirement(): string {
  *
  * @return bool True if meets minimum requirements, false otherwise.
  */
-function site_meets_php_requirements(): bool {
+function site_meets_php_requirements() {
 	return version_compare( phpversion(), minimum_php_requirement(), '>=' );
 }
 
@@ -50,7 +53,7 @@ if ( ! site_meets_php_requirements() ) {
 					<?php
 					echo wp_kses_post(
 						sprintf(
-						/* translators: %s: Minimum required PHP version */
+						    /* translators: %s: Minimum required PHP version */
 							__( 'Insert Special Characters requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'insert-special-characters' ),
 							esc_html( minimum_php_requirement() )
 						)
@@ -64,167 +67,8 @@ if ( ! site_meets_php_requirements() ) {
 	return;
 }
 
-/**
- * Registers JS and CSS assets.
- */
-function register_assets() {
-	$asset_data_file = trailingslashit( plugin_dir_path( __FILE__ ) ) . 'build/index.asset.php';
-
-	if ( ! file_exists( $asset_data_file ) ) {
-		return;
-	}
-
-	$script_data = include $asset_data_file;
-
-	wp_register_script(
-		'insert-special-characters',
-		plugin_dir_url( __FILE__ ) . 'build/index.js',
-		$script_data['dependencies'],
-		$script_data['version'],
-		true
-	);
-
-	wp_register_style(
-		'insert-special-characters-css',
-		plugin_dir_url( __FILE__ ) . 'build/index.css',
-		array(),
-		$script_data['version']
-	);
-
-	wp_set_script_translations( 'insert-special-characters', 'insert-special-characters', plugin_dir_path( __FILE__ ) . 'languages' );
+if ( ! site_meets_php_requirements() ) {
+	return;
 }
 
-add_action( 'init', __NAMESPACE__ . '\register_assets' );
-
-
-/**
- * Enqueue the admin JavaScript assets.
- */
-function gcm_block_enqueue_scripts() {
-
-	wp_enqueue_script( 'insert-special-characters' );
-
-	wp_enqueue_style( 'insert-special-characters-css' );
-
-	wp_add_inline_script(
-		'insert-special-characters',
-		sprintf(
-			'var tenupIscVars = window.tenupIscVars || {}; tenupIscVars = %1$s',
-			wp_json_encode(
-				array(
-					'most_read_palette' => get_most_used_palette_setting(),
-				)
-			)
-		)
-	);
-}
-add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\gcm_block_enqueue_scripts' );
-
-/**
- * Registers settings fields.
- */
-function register_settings_fields() {
-	register_setting(
-		'writing',
-		'tenup_isc_most_read_palette',
-		array(
-			'type'         => 'boolean',
-			'show_in_rest' => true,
-			'default'      => false,
-		)
-	);
-
-	add_settings_section(
-		'tenup_isc_writing_section',
-		esc_html__( 'Insert Special Characters', 'insert-special-characters' ),
-		null,
-		'writing'
-	);
-
-	add_settings_field(
-		'tenup_isc_most_read_palette',
-		esc_html__( 'Most used characters palette', 'insert-special-characters' ),
-		__NAMESPACE__ . '\render_isc_writing_setting',
-		'writing',
-		'tenup_isc_writing_section',
-		array(
-			'label_for' => 'tenup_isc_most_read_palette',
-		)
-	);
-}
-add_action( 'admin_init', __NAMESPACE__ . '\register_settings_fields' );
-
-/**
- * Renders settings fields.
- */
-function render_isc_writing_setting() {
-	$option = get_most_used_palette_setting();
-	?>
-	<p>
-		<label for="tenup_isc_most_read_palette">
-			<input
-				type="checkbox"
-				name="tenup_isc_most_read_palette"
-				id="tenup_isc_most_read_palette"
-				<?php checked( $option, true, true ); ?>
-			>
-			<?php esc_html_e( 'Check this to enable the most used character palette.', 'insert-special-characters' ); ?>
-		</label>
-	</p>
-
-	<?php if ( $option ) : ?>
-	<p>
-		<button class="button secondary" id="isc_reset_palette" type="button" style="margin-top: 16px;">
-			<?php esc_html_e( 'Clear palette', 'insert-special-characters' ); ?>
-		</button>
-		&nbsp;
-		<?php esc_html_e( 'Press this to clear palette data.', 'insert-special-characters' ); ?>
-	</p>
-		<?php
-	endif;
-}
-
-/**
- * Helper function to get most used character palette setting.
- *
- * @return boolean
- */
-function get_most_used_palette_setting() {
-	return 'on' === get_option( 'tenup_isc_most_read_palette' );
-}
-
-/**
- * Loads admin scripts.
- *
- * @param string $hook The current admin page.
- */
-function load_admin_scripts( $hook ) {
-	if ( 'options-writing.php' !== $hook ) {
-		return;
-	}
-
-	$asset_data_file = trailingslashit( plugin_dir_path( __FILE__ ) ) . 'build/admin.asset.php';
-
-	if ( ! file_exists( $asset_data_file ) ) {
-		return;
-	}
-
-	$script_data = include $asset_data_file;
-
-	wp_enqueue_script(
-		'insert-special-characters-admin-js',
-		plugin_dir_url( __FILE__ ) . 'build/admin.js',
-		$script_data['dependencies'],
-		$script_data['version'],
-		true
-	);
-
-	wp_localize_script(
-		'insert-special-characters-admin-js',
-		'tenupIscAdminVars',
-		array(
-			'palette_deleted_message' => __( 'Palette cleared', 'insert-special-characters' ),
-		)
-	);
-}
-add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\load_admin_scripts' );
+require_once __DIR__ . '/inc/plugin.php';

--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -18,6 +18,53 @@
 namespace InsertSpecialCharacters;
 
 /**
+ * Get the minimum version of PHP required by this plugin.
+ *
+ * @since 1.0.8
+ *
+ * @return string Minimum version required.
+ */
+function minimum_php_requirement(): string {
+	return '7.4';
+}
+
+/**
+ * Whether PHP installation meets the minimum requirements
+ *
+ * @since 1.0.8
+ *
+ * @return bool True if meets minimum requirements, false otherwise.
+ */
+function site_meets_php_requirements(): bool {
+	return version_compare( phpversion(), minimum_php_requirement(), '>=' );
+}
+
+// Try to load the plugin files, ensuring our PHP version is met first.
+if ( ! site_meets_php_requirements() ) {
+	add_action(
+		'admin_notices',
+		function() {
+			?>
+			<div class="notice notice-error">
+				<p>
+					<?php
+					echo wp_kses_post(
+						sprintf(
+						/* translators: %s: Minimum required PHP version */
+							__( 'Insert Special Characters requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'insert-special-characters' ),
+							esc_html( minimum_php_requirement() )
+						)
+					);
+					?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+	return;
+}
+
+/**
  * Registers JS and CSS assets.
  */
 function register_assets() {

--- a/insert-special-characters.php
+++ b/insert-special-characters.php
@@ -53,7 +53,7 @@ if ( ! site_meets_php_requirements() ) {
 					<?php
 					echo wp_kses_post(
 						sprintf(
-						    /* translators: %s: Minimum required PHP version */
+							/* translators: %s: Minimum required PHP version */
 							__( 'Insert Special Characters requires PHP version %s or later. Please upgrade PHP or disable the plugin.', 'insert-special-characters' ),
 							esc_html( minimum_php_requirement() )
 						)


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
In this PR, I'm adding a check for the minimum required PHP version before attempting to load the plugin files. If the condition is not met an admin notice is displayed and the plugin files are not loaded.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/insert-special-characters/issues/205

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
* To see the admin notice and have the plugin functionality not loaded, try to load the plugin on a site with PHP version lower that 7.4.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Check for minimum required PHP version before loading the plugin


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @kmgalanakis 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
