### PR TITLE
Ensure the `attributes.content` param exists before using it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,10 +114,15 @@ registerFormatType( type, {
 		} );
 
 		useEffect( () => {
-			const content = selectedBlock.attributes.content.replace(
+			const content = selectedBlock.attributes?.content?.replace(
 				/<insertspecialcharacters>|<\/insertspecialcharacters>/g,
 				''
 			);
+
+			if ( ! content ) {
+				return;
+			}
+
 			dispatch( caretDataStore ).setClientId( selectedBlock.clientId );
 
 			const preBreak = content.substring( 0, start );


### PR DESCRIPTION
### Description of the Change

As described on [WordPress.org](https://wordpress.org/support/topic/after-update-other-blocks-crash/), with the latest update, some blocks are crashing. I installed the plugin mentioned ([Spectra Blocks](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/)) and when using the blocks that plugin adds (like Call to Action) I was able to reproduce the reported issue.

The problem stems from the work done in #207, in particular this line: https://github.com/10up/insert-special-characters/pull/207/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R117. It seems some blocks don't have the `attributes.content` set, so when we try and access that, it throws a JS error and prevents the block from working.

I've fixed that in this PR but ensuring that data exists before we try to use it and that does seem to fix the reported issue. I'm not sure if it's the best approach though or if there's a better way to handle this. In addition, while this prevents the block from breaking, the toolbar is still shown but doesn't seem to work. Not sure if there's a way to make the toolbar work in this instance or if there's a way to remove the toolbar all together? Not sure if this is an instance where we could be doing something different or if it's an issue with how these custom blocks are built, since they don't seem to have the standard `content` attribute.

### How to test the Change

1. Install the latest released version of this plugin
2. Install the [Spectra Blocks](https://wordpress.org/plugins/ultimate-addons-for-gutenberg/) plugin
3. Create a new post and add the Call to Action block. Note that the block throws an error
4. Add the changes from this PR and test again. The Call to Action block should work now
5. Ensure core blocks (like Paragraphs and Headings) still show the toolbar and inserting special characters work

### Changelog Entry

> Fixed - Ensure custom blocks don't break.

### Credits
Props @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
