### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, adamsilverstein, johnwatkins0, jeffpaul
 Tags:              Special Characters, Character Map, Omega, Gutenberg, Block, block editor
 Stable tag:        1.1.2
 Requires at least: 6.1
-Tested up to:      6.4
+Tested up to:      6.6
 Requires PHP:      7.4
 License:           GPLv2
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change

Per testing, reviews, feedback in #246 this PR bumps the WordPress "tested up to" version 6.6.

Closes #246.

### How to test the Change

n/a

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.6.

### Credits

Props @sudip-md @sonali886 @jeffpaul @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
