### PR TITLE
make UI more consistent with core WP

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { BlockControls, RichTextShortcut } from '@wordpress/block-editor';
-import { Popover, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton, Dropdown } from '@wordpress/components';
 import { applyFilters } from '@wordpress/hooks';
 import { displayShortcut } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -151,21 +151,10 @@ registerFormatType( type, {
 		}, [ isPopoverActive, memoizedPopoverRef ] );
 
 		const characters = applyFilters( `${ name }-characters`, Chars );
-		// Display the character map when it is active.
-		const specialCharsPopover = isPopoverActive && (
-			<Popover
-				className="character-map-popover"
-				placement="bottom-start"
-				focusOnMount="firstElement"
-				key="charmap-popover"
-				anchor={ contentRef.current }
-				expandOnMobile={ true }
-				headerTitle={ __(
-					'Insert Special Character',
-					'insert-special-characters'
-				) }
-				ref={ popoverRef }
-			>
+
+		// Character map component used by the dropdown render.
+		const characterMap = () => {
+			return (
 				<CharacterMap
 					characterData={ characters }
 					onSelect={
@@ -207,24 +196,33 @@ registerFormatType( type, {
 						'insert-special-characters'
 					) }
 				/>
-			</Popover>
-		);
+			);
+		};
 
 		return (
 			<Fragment>
 				<BlockControls group="other">
-					<ToolbarGroup>
-						<ToolbarButton
-							className={ `toolbar-button-with-text toolbar-button__advanced-${ name }` }
-							icon="editor-customchar"
-							isPressed={ isPopoverActive }
-							label={ title }
-							onClick={ () =>
-								setIsPopoverActive( ! isPopoverActive )
-							}
-							shortcut={ displayShortcut.primary( character ) }
-						/>
-					</ToolbarGroup>
+					<Dropdown
+						className="insert-special-character__dropdown"
+						open={ isPopoverActive }
+						onToggle={ () =>
+							setIsPopoverActive( ! isPopoverActive )
+						}
+						contentClassName="insert-special-character__dropdown-content"
+						renderToggle={ ( { onToggle, isOpen } ) => (
+							<ToolbarButton
+								icon="editor-customchar"
+								label={ title }
+								className="toolbar-button__advanced-insertspecialcharacters"
+								onClick={ onToggle }
+								isActive={ isOpen }
+								shortcut={ displayShortcut.primary(
+									character
+								) }
+							/>
+						) }
+						renderContent={ characterMap }
+					/>
 				</BlockControls>
 				<Fragment>
 					<RichTextShortcut
@@ -233,7 +231,6 @@ registerFormatType( type, {
 						onUse={ () => setIsPopoverActive( ! isPopoverActive ) }
 					/>
 				</Fragment>
-				{ specialCharsPopover }
 			</Fragment>
 		);
 	},


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
This update moves makes the interface more consistent with the core UI by consistent padding to the toolbar button and popover element.

#### Before:
![image](https://github.com/user-attachments/assets/dff2d333-182a-4b82-8d74-090970de56fc)

#### After: 
![image](https://github.com/user-attachments/assets/b75d312d-52c5-40a8-ac60-454fad7feb4b)


<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #231 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
* Add new paragraph text
* Press cmd + o to toggle character inserter
* Observe proper padding in both toolbar button and popover item

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

Changed UI to have padding consistent with WP Core


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
@psorensen @fabiankaegy 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
