### PR TITLE
Bump WordPress "tested up to" version 6.7 on `trunk`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors:      10up, adamsilverstein, johnwatkins0, jeffpaul
 Tags:              Special Characters, Character Map, Omega, Gutenberg, Block, block editor
 Stable tag:        1.1.2
-Requires at least: 6.1
-Tested up to:      6.6
+Requires at least: 6.5
+Tested up to:      6.7
 Requires PHP:      7.4
 License:           GPLv2
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
@@ -21,7 +21,7 @@ Development takes place in the [GitHub repository](https://github.com/10up/inser
 == Technical Notes ==
 
 * Requires PHP 7.4+.
-* Requires [WordPress](http://wordpress.org/) 5.7+
+* Requires [WordPress](http://wordpress.org/) 6.5+
 * Issues and Pull requests welcome in the [GitHub repository](https://github.com/10up/insert-special-characters).
 
 == Installation ==


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Follows on from #273 to port those changes to `trunk` within the `readme.txt` file so that the readme updater action will fire and update dotorg. Note this has to add the "requires at least" WP minimum back into the readme file as updating that in the main php file would cause the action to fail.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #270.

### How to test the Change
Update to 6.7 release candidate, confirm plugin works as expected.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
n/a

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jeffpaul.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
