### PR TITLE
Feat: Add Recently Used Section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file, per [the Keep a Changelog standard](http://keepachangelog.com/).
 
 ## [Unreleased] - TBD
+- Add `Recently Used` section (props [@badasswp](https://github.com/badasswp) via [#279](https://github.com/10up/insert-special-characters/pull/279)).
 
 ## [1.1.3] - 2024-11-18
 ### Changed

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,0 +1,30 @@
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Recent Special Characters.
+ *
+ * This filter will add the "Recently Used" category and display
+ * recently selected special characters.
+ *
+ * @param {Object} characters Default Characters.
+ * @return {Object} All Characters including Recently used characters.
+ */
+addFilter(
+	'insertspecialcharacters-characters',
+	'recentCharacters',
+	function ( characters ) {
+		const recentCharacters =
+			JSON.parse( localStorage.getItem( 'recentCharacters' ) ) || [];
+
+		if ( recentCharacters?.length ) {
+			return {
+				'Recently Used': recentCharacters,
+				...characters,
+			};
+		}
+
+		return {
+			...characters,
+		};
+	}
+);

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 
 import { CharacterMap } from 'react-character-map';
 import './insert-special-characters.scss';
+import './filter';
 
 // Load the default Chars provided by react-character-map component.
 import Chars from '../node_modules/react-character-map/dist/component/chars.json';
@@ -152,6 +153,34 @@ registerFormatType( type, {
 
 		const characters = applyFilters( `${ name }-characters`, Chars );
 
+		/**
+		 * Set Recent Characters.
+		 *
+		 * This function will store the recently used characters
+		 * in the local storage for ease.
+		 *
+		 * @param {Object} obj The special character object.
+		 */
+		const setRecentCharacters = ( obj ) => {
+			const recentCharacters =
+				JSON.parse( localStorage.getItem( 'recentCharacters' ) ) || [];
+
+			const index = recentCharacters.findIndex(
+				( e ) => e.char === obj.char
+			);
+
+			if ( index !== -1 ) {
+				recentCharacters.splice( index, 1 );
+			}
+
+			recentCharacters.unshift( obj );
+
+			localStorage.setItem(
+				'recentCharacters',
+				JSON.stringify( recentCharacters )
+			);
+		};
+
 		// Character map component used by the dropdown render.
 		const characterMap = () => {
 			return (
@@ -162,9 +191,14 @@ registerFormatType( type, {
 						( obj ) => {
 							insertCharacter( obj.char );
 							setIsPopoverActive( false );
+							setRecentCharacters( obj );
 						}
 					}
 					categoryNames={ {
+						Recent: __(
+							'Recently Used',
+							'insert-special-characters'
+						),
 						Math: __( 'Math', 'insert-special-characters' ),
 						Currency: __( 'Currency', 'insert-special-characters' ),
 						Punctuation: __(


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/10up/convert-to-blocks/issues/229).

### Description of the Change

We need to add a new tabbed section called **Recently Used** that ideally appears as the first tab once someone has previously utilised ISC to add a special character into their post. This section should show the last 80 unique special characters (5 rows of 16 characters in our display).

This PR implements this correctly.

Closes #229 

### How to test the Change

- Pull PR to local.
- Build plugin correctly like so: `composer install && npm start`.
- Create a new post and type in some text.
- Click on the Special characters icon located in the toolbar and select a character.
- Proceed to another Special character and you should now see the **Recently Used** section with the recent character you just used like so:

<img width="603" alt="Screenshot 2025-03-07 at 06 17 18" src="https://github.com/user-attachments/assets/8922a702-6aca-42bd-a219-524ae0852587" />

---

https://github.com/user-attachments/assets/e2a4fe48-470a-4873-a572-0dbac1c33065

### Changelog Entry
> Added - New feature

### Credits
@badasswp

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.