### PR TITLE
Bump: "Tested up to" WP 6.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, adamsilverstein, johnwatkins0, jeffpaul
 Tags:              Special Characters, Character Map, Omega, character inserter, symbols
 Stable tag:        1.1.3
 Requires at least: 6.5
-Tested up to:      6.7
+Tested up to:      6.8
 Requires PHP:      7.4
 License:           GPLv2
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change

Updates WordPress "Tested Up To" version to 6.8.

![image2](https://github.com/user-attachments/assets/3d360aef-4882-44b3-800c-1692b6123622)
![image1](https://github.com/user-attachments/assets/fd994d92-5216-467a-8e01-00f4c0ffec43)

Closes #281

### Changelog Entry
> Developer - Bump WordPress "tested up to" version 6.8.

### Credits
Props @godleman 


### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
