### PR TITLE
Bump tested up to header to indicate WordPress 6.9 support.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, adamsilverstein, johnwatkins0, jeffpaul
 Tags:              Special Characters, Character Map, Omega, character inserter, symbols
 Stable tag:        1.1.3
 Requires at least: 6.6
-Tested up to:      6.8
+Tested up to:      6.9
 Requires PHP:      7.4
 License:           GPLv2
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change

Bump tested up to header to indicate WordPress 6.9 support.

Closes #293 

### How to test the Change

N/A: See testing notes on the related issue.

### Changelog Entry
> Changed - Bump tested up to header to indicate WordPress 6.9 support.

### Credits
Props @peterwilsoncc 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
