### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, adamsilverstein, johnwatkins0, jeffpaul
 Tags:              Special Characters, Character Map, Omega, character inserter, symbols
 Stable tag:        1.1.3
 Requires at least: 6.6
-Tested up to:      7.0
+Tested up to:      7.1
 Requires PHP:      7.4
 License:           GPLv2
 License URI:       https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1 RC1. The plugin functions as expected with the 7.1 RC1

Closes #329 

### How to test the Change

1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Create a post with special characters. 
3. Check different categories, most used, etc
4. No warnings on console or functionality is broken.

### Changelog Entry
> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits
Props @oscarssanchezz 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
